### PR TITLE
Changed to implement Serializable

### DIFF
--- a/s3blobs/src/play/modules/s3blobs/S3Blob.java
+++ b/s3blobs/src/play/modules/s3blobs/S3Blob.java
@@ -18,7 +18,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 
-public class S3Blob implements BinaryField, UserType {
+public class S3Blob implements BinaryField, UserType, Serializable {
 
 	static String s3Bucket;
 	static AmazonS3 s3Client;


### PR DESCRIPTION
Changed S3Blob to implement Serializable.  There doesn't seem to be any good reason that I can see why this would be problematic and doing so allows objects that contain fields of this type to be serialized.  This is particularly important when storing objects in a distributed cache like memcached.
