### PR TITLE
Uplifted for Play 1.5.1 and AWS S3 1.11.455 - some signature changes

### DIFF
--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -2,4 +2,4 @@ self: play -> s3blobs 0.3
 
 require:
     - play
-    - com.amazonaws -> aws-java-sdk-s3 1.11.228
+    - com.amazonaws -> aws-java-sdk-s3 1.11.455

--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -1,4 +1,4 @@
-self: play -> s3blobs 0.3
+self: play -> s3blobs 0.4
 
 require:
     - play

--- a/src/play/modules/s3blobs/S3Blob.java
+++ b/src/play/modules/s3blobs/S3Blob.java
@@ -8,7 +8,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 
 import org.hibernate.HibernateException;
-import org.hibernate.engine.spi.SessionImplementor;
+//import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.StringType;
 import org.hibernate.usertype.UserType;
 
@@ -117,20 +118,26 @@ public class S3Blob implements BinaryField, UserType, Serializable {
     }
 
     @Override
-    public Object nullSafeGet(ResultSet rs, String[] names, SessionImplementor sessionImplementor, Object o) throws HibernateException, SQLException {
-        String val = StringType.INSTANCE.nullSafeGet(rs, names[0], sessionImplementor);
-        if (val == null || val.length() == 0 || !val.contains("|")) {
-            return new S3Blob();
+    public Object nullSafeGet(ResultSet resultSet, String[] strings, SharedSessionContractImplementor sharedSessionContractImplementor, Object o) throws HibernateException, SQLException
+    {
+        String val = StringType.INSTANCE.nullSafeGet(resultSet, strings[0], sharedSessionContractImplementor);
+        if (val == null || val.length() == 0 || !val.contains("|") || val.equals("null|null"))
+        {
+            return null;
         }
         return new S3Blob(val.split("[|]")[0], val.split("[|]")[1]);
     }
 
     @Override
-    public void nullSafeSet(PreparedStatement ps, Object o, int i, SessionImplementor sessionImplementor) throws HibernateException, SQLException {
-        if (o != null) {
-            ps.setString(i, ((S3Blob) o).bucket + "|" + ((S3Blob) o).key);
-        } else {
-            ps.setNull(i, Types.VARCHAR);
+    public void nullSafeSet(PreparedStatement preparedStatement, Object o, int i, SharedSessionContractImplementor sharedSessionContractImplementor) throws HibernateException, SQLException
+    {
+        if (o != null)
+        {
+            preparedStatement.setString(i, ((S3Blob) o).bucket + "|" + ((S3Blob) o).key);
+        }
+        else
+        {
+            preparedStatement.setNull(i, Types.VARCHAR);
         }
     }
 

--- a/src/play/modules/s3blobs/S3Blobs.java
+++ b/src/play/modules/s3blobs/S3Blobs.java
@@ -5,8 +5,6 @@ import play.Play;
 import play.PlayPlugin;
 import play.exceptions.ConfigurationException;
 
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
-
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
@@ -40,7 +38,7 @@ public class S3Blobs extends PlayPlugin {
         AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
 
         S3Blob.s3Client = AmazonS3ClientBuilder.standard()
-                .withRegion(Regions.EU_WEST_2)
+                .withRegion(Regions.fromName(Play.configuration.getProperty("s3.region")))
                 .build();
         
         if (!S3Blob.s3Client.doesBucketExist(S3Blob.s3Bucket)) {

--- a/src/play/modules/s3blobs/S3Blobs.java
+++ b/src/play/modules/s3blobs/S3Blobs.java
@@ -5,9 +5,15 @@ import play.Play;
 import play.PlayPlugin;
 import play.exceptions.ConfigurationException;
 
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
 
 public class S3Blobs extends PlayPlugin {
 
@@ -32,7 +38,11 @@ public class S3Blobs extends PlayPlugin {
         String accessKey = Play.configuration.getProperty("aws.access.key");
         String secretKey = Play.configuration.getProperty("aws.secret.key");
         AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-        S3Blob.s3Client = new AmazonS3Client(awsCredentials);
+
+        S3Blob.s3Client = AmazonS3ClientBuilder.standard()
+                .withRegion(Regions.EU_WEST_2)
+                .build();
+        
         if (!S3Blob.s3Client.doesBucketExist(S3Blob.s3Bucket)) {
             S3Blob.s3Client.createBucket(S3Blob.s3Bucket);
         }


### PR DESCRIPTION
Updated the dependencies for AWS S3 SDK 1.11.455, which is latest at time of writing.  This introduced some signature changes thru deprecation, the most notable of which is the SharedSessionContractImplementor replacing the SessionImplementor and using S3ClientBuilder to create the client, specifying Region (not sure if this is wholly mandatory, but it seemed to be in my app that uses S3Blob)

Play Framework 1.5.1 changes means the method signatures for nullableGet and nullableSet are slightly different too when overriding from the Interface